### PR TITLE
UTC-20230925-add-ignore-deprecations

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -11,6 +11,7 @@
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
     "resolveJsonModule": true,
+    "ignoreDeprecations":"5.0",
     /**
      * To have warnings / errors of the Svelte compiler at the
      * correct position, enable source maps by default.


### PR DESCRIPTION
This fixes deprecation error according to VSCode recommendations.
![Screenshot 2023-09-25 at 12 14 51 PM](https://github.com/bmartinez287/SvelteWordpressNews/assets/82905787/ae2eda53-b56d-421a-8512-d22ff844d90e)
